### PR TITLE
Fix: rt를 httponly 쿠키에 담도록 수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     testImplementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter-test:3.0.3'
     testImplementation 'org.springframework.security:spring-security-test'
     compileOnly 'org.projectlombok:lombok'

--- a/src/main/java/com/threeping/syncday/common/ResponseDTO.java
+++ b/src/main/java/com/threeping/syncday/common/ResponseDTO.java
@@ -10,8 +10,13 @@ import jakarta.validation.constraints.NotNull;
 import lombok.Data;
 import org.springframework.http.HttpStatus;
 import org.springframework.lang.Nullable;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+
+import java.util.HashMap;
+import java.util.Map;
 
 //필기. 응답 DTO통일
 @Data
@@ -81,6 +86,30 @@ public class ResponseDTO<T> {
                 false,
                 null,
                 ExceptionDTO.of(ErrorCode.INVALID_PARAMETER_FORMAT)
+        );
+    }
+
+    public static ResponseDTO<Object> failValidation(MethodArgumentNotValidException e) {
+        // 첫 번째 에러 메시지만 사용
+        String errorMessage = e.getBindingResult().getAllErrors().get(0).getDefaultMessage();
+
+        // 에러 메시지에 따른 ErrorCode 매핑
+        ErrorCode errorCode;
+        if (errorMessage.contains("영문자, 숫자, 특수문자")) {
+            errorCode = ErrorCode.INVALID_PASSWORD_PATTERN;
+        } else if (errorMessage.contains("8자 이상 20자 이하")) {
+            errorCode = ErrorCode.INVALID_PASSWORD_LENGTH;
+        } else if (errorMessage.contains("3번 이상 연속")) {
+            errorCode = ErrorCode.INVALID_PASSWORD_REPEAT;
+        } else {
+            errorCode = ErrorCode.INVALID_INPUT_VALUE;
+        }
+
+        return new ResponseDTO<>(
+                HttpStatus.BAD_REQUEST,
+                false,
+                null,
+                ExceptionDTO.of(errorCode)
         );
     }
 }

--- a/src/main/java/com/threeping/syncday/common/exception/ErrorCode.java
+++ b/src/main/java/com/threeping/syncday/common/exception/ErrorCode.java
@@ -19,10 +19,11 @@ public enum ErrorCode {
     INVALID_REQUEST_BODY(40011, HttpStatus.BAD_REQUEST, "잘못된 요청 본문입니다."),
     MISSING_REQUIRED_FIELD(40012, HttpStatus.BAD_REQUEST, "필수 필드가 누락되었습니다."),
     EXIST_USER_ID(40013, HttpStatus.BAD_REQUEST, "이미 존재하는 회원입니다."),
-    INVALID_PASSWORD(40014, HttpStatus.BAD_REQUEST, "비밀번호가 일치하지 않습니다."),
+    INVALID_PASSWORD(40014, HttpStatus.BAD_REQUEST, "현재 비밀번호가 일치하지 않습니다."),
     EXIST_PASSWORD(40015, HttpStatus.BAD_REQUEST, "현재 비밀번호와 일치합니다."),
-
-
+    INVALID_PASSWORD_PATTERN(40016, HttpStatus.BAD_REQUEST, "비밀번호는 영문자, 숫자, 특수문자를 포함해야 합니다."),
+    INVALID_PASSWORD_LENGTH(40017, HttpStatus.BAD_REQUEST, "최소 8자 이상 20자 이하로 구성해야합니다."),
+    INVALID_PASSWORD_REPEAT(40018, HttpStatus.BAD_REQUEST, "동일한 문자를 3번 이상 연속해서 사용할 수 없습니다."),
 
 
     //401
@@ -33,12 +34,14 @@ public enum ErrorCode {
     TOKEN_TYPE_ERROR(40104, HttpStatus.UNAUTHORIZED, "토큰 타입이 일치하지 않거나 비어있습니다."),
     TOKEN_UNSUPPORTED_ERROR(40105, HttpStatus.UNAUTHORIZED, "지원하지않는 토큰입니다."),
     TOKEN_GENERATION_ERROR(40106, HttpStatus.UNAUTHORIZED, "토큰 생성에 실패하였습니다."),
-    LOGOUT_ACCESS_TOKEN(400113, HttpStatus.BAD_REQUEST, "로그아웃된 accessToken입니다."),
     TOKEN_UNKNOWN_ERROR(40107, HttpStatus.UNAUTHORIZED, "알 수 없는 토큰입니다."),
     LOGIN_FAILURE(40108, HttpStatus.UNAUTHORIZED, "로그인에 실패했습니다"),
     UNAUTHORIZED_ACCESS(40110, HttpStatus.UNAUTHORIZED, "인증되지 않은 접근입니다."),
     EXPIRED_SESSION(40111, HttpStatus.UNAUTHORIZED, "세션이 만료되었습니다."),
     ACCESS_DENIED(40312, HttpStatus.FORBIDDEN, "접근이 거부되었습니다."),
+    LOGOUT_ACCESS_TOKEN(400113, HttpStatus.BAD_REQUEST, "로그아웃된 accessToken입니다."),
+    NOT_FOUND_REFRESH_TOKEN(40314, HttpStatus.UNAUTHORIZED, "refreshToken이 존재하지 않습니다."),
+    NOT_FOUND_COOKIE(40315, HttpStatus.BAD_REQUEST, "쿠키가 없습니다."),
 
 
     //403

--- a/src/main/java/com/threeping/syncday/user/command/application/controller/UserCommandController.java
+++ b/src/main/java/com/threeping/syncday/user/command/application/controller/UserCommandController.java
@@ -108,6 +108,7 @@ public class UserCommandController {
     )
     @PostMapping("/logout")
     public ResponseDTO<?> logout() {
+
         return ResponseDTO.ok("로그아웃 성공");
     }
 }

--- a/src/main/java/com/threeping/syncday/user/command/domain/vo/LoginRequestVO.java
+++ b/src/main/java/com/threeping/syncday/user/command/domain/vo/LoginRequestVO.java
@@ -1,7 +1,6 @@
 package com.threeping.syncday.user.command.domain.vo;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
 
 @AllArgsConstructor
@@ -9,14 +8,11 @@ import lombok.*;
 @Getter
 @Setter
 @EqualsAndHashCode
-@ToString
 public class LoginRequestVO {
 
     @JsonProperty("email")
-    @Schema(description = "유저 아이디", required = true, example = "syncday1211@gmail.com")
-    private String emil;
+    private String email;
 
     @JsonProperty("password")
-    @Schema(description = "유저 비밀번호", required = true, example = "syncday1211!", minLength = 8, maxLength = 20)
     private String password;
 }

--- a/src/main/java/com/threeping/syncday/user/query/controller/AuthDocsController.java
+++ b/src/main/java/com/threeping/syncday/user/query/controller/AuthDocsController.java
@@ -68,7 +68,7 @@ public class AuthDocsController {
         log.info("Swagger API login request 들어옴: {}", loginRequestVO);
 
         UsernamePasswordAuthenticationToken authRequest =
-                new UsernamePasswordAuthenticationToken(loginRequestVO.getEmil(),
+                new UsernamePasswordAuthenticationToken(loginRequestVO.getEmail(),
                         loginRequestVO.getPassword(), new ArrayList<>());
 
         Authentication authentication =

--- a/src/main/java/com/threeping/syncday/user/query/service/UserQueryServiceImpl.java
+++ b/src/main/java/com/threeping/syncday/user/query/service/UserQueryServiceImpl.java
@@ -2,8 +2,8 @@ package com.threeping.syncday.user.query.service;
 
 import com.threeping.syncday.common.exception.CommonException;
 import com.threeping.syncday.common.exception.ErrorCode;
-import com.threeping.syncday.user.command.domain.aggregate.UserEntity;
 import com.threeping.syncday.user.command.application.dto.UserDTO;
+import com.threeping.syncday.user.command.domain.aggregate.UserEntity;
 import com.threeping.syncday.user.query.repository.UserMapper;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -13,7 +13,6 @@ import org.springframework.security.core.userdetails.User;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.sql.Timestamp;
 import java.time.format.DateTimeFormatter;
@@ -32,9 +31,7 @@ class UserQueryServiceImpl implements UserQueryService {
     }
 
     @Override
-    @Transactional(readOnly = true)
     public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
-        log.info("loadUserByUsername: {}", username);
         UserEntity existingUser = userMapper.findByEmail(username);
 
         if (existingUser == null) {
@@ -56,7 +53,6 @@ class UserQueryServiceImpl implements UserQueryService {
     }
 
     @Override
-    @Transactional(readOnly = true)
     public UserDTO findByEmail(String email) {
         UserEntity user = userMapper.findByEmail(email);
 
@@ -68,18 +64,19 @@ class UserQueryServiceImpl implements UserQueryService {
         userDTO.setUserId(user.getUserId());
         userDTO.setUserName(user.getUserName());
         userDTO.setEmail(user.getEmail());
+        userDTO.setPassword(user.getPassword());
         userDTO.setProfilePhoto(user.getProfilePhoto());
+        userDTO.setPhoneNumber(user.getPhoneNumber());
         userDTO.setPosition(user.getPosition());
         userDTO.setJoinYear(timeStampToString(user.getJoinYear()));
         userDTO.setTeamId(user.getTeamId());
-        userDTO.setLastAccessTime(user.getLastAccessTime()
-                .toLocalDateTime().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")));
+        userDTO.setLastAccessTime(user.getLastAccessTime().toLocalDateTime().format(DateTimeFormatter.ISO_DATE_TIME));
 
         return userDTO;
     }
 
     private String timeStampToString(Timestamp joinYear) {
         return joinYear.toLocalDateTime()
-                .format(DateTimeFormatter.ofPattern("yyyy-MM-dd"));
+                .format(DateTimeFormatter.ofPattern("yyyyMMdd"));
     }
 }

--- a/src/main/java/com/threeping/syncday/user/security/CustomLogoutHandler.java
+++ b/src/main/java/com/threeping/syncday/user/security/CustomLogoutHandler.java
@@ -34,9 +34,9 @@ public class CustomLogoutHandler implements LogoutHandler {
             try {
                 Claims claims = jwtUtil.parseClaims(accessToken);
                 String email = claims.getSubject();
-
                 // redis에서 rt제거
                 redisTemplate.delete("RT:" + email);
+                log.info("redis에서 RT 제거됌");
 
                 // redis에 at 블랙리스트로 등록(서버 차원에서 at를 만료시킬 방법이 없으므로)
                 // at 토큰의 남은 저장 시간을 redis에 저장해놓고 시간이 지나면 자동 삭제되도록 구현

--- a/src/main/java/com/threeping/syncday/user/security/JwtUtil.java
+++ b/src/main/java/com/threeping/syncday/user/security/JwtUtil.java
@@ -2,6 +2,7 @@ package com.threeping.syncday.user.security;
 
 import com.threeping.syncday.common.exception.CommonException;
 import com.threeping.syncday.common.exception.ErrorCode;
+import com.threeping.syncday.user.query.service.UserQueryService;
 import io.jsonwebtoken.*;
 import io.jsonwebtoken.io.Decoders;
 import io.jsonwebtoken.security.Keys;
@@ -9,11 +10,14 @@ import io.jsonwebtoken.security.SecurityException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.User;
 import org.springframework.stereotype.Component;
 
 import java.security.Key;
 import java.util.Base64;
 import java.util.Date;
+import java.util.stream.Collectors;
 
 // Token의 유효성 검사
 @Component
@@ -23,15 +27,17 @@ public class JwtUtil {
     private final Key secret;
     private final long accessExpiration;
     private final long refreshExpiration;
+    private final UserQueryService userQueryService;
 
     @Autowired
     public JwtUtil(@Value("${token.secret}") String secret,
                    @Value("${token.access-expiration-time}") long accessExpiration,
-                   @Value("${token.refresh-expiration-time}") long refreshExpiration) {
+                   @Value("${token.refresh-expiration-time}") long refreshExpiration, UserQueryService userQueryService) {
         byte[] keyBytes = Decoders.BASE64.decode(secret);
         this.secret = Keys.hmacShaKeyFor(keyBytes);
         this.accessExpiration = accessExpiration;
         this.refreshExpiration = refreshExpiration;
+        this.userQueryService = userQueryService;
     }
 
     // accessToken으로부터 Claims추출
@@ -56,7 +62,14 @@ public class JwtUtil {
 
     // At 생성 로직
     public String generateAccessToken(String userEmail) {
+
+        User userDetails = (User) userQueryService.loadUserByUsername(userEmail);
+
         Claims claims = Jwts.claims().setSubject(userEmail);
+        claims.put("auth", userDetails.getAuthorities().stream()
+                .map(GrantedAuthority::getAuthority)
+                .collect(Collectors.toList()));
+
         return buildToken(claims, accessExpiration);
     }
 


### PR DESCRIPTION
---
name: rt를 httponly 쿠키에 담도록 수정
about:  기존방식은 단순히 at를 변수에 담아 관리하면서 다른 도메인의 api를 호출할 수 있었으나, 새로고침을 할 경우 세션이 만료되면서
모든 정보가 다 날라간다는 단점이 있었습니다. 따라서 새로고침을 하더라도 유저의 정보를 유지할 수 있도록 rt를 httponly 쿠키에 담아 xss 공격으로부터 안전하게 지키면서 rt 기반으로 at를 계속 발급받게 구현하였습니다.
또한 로그아웃 시에는 쿠키를 비움으로써 로그아웃 상태로 다른 사이트를 방문해도 rt가 유출되지 않도록 수정했습니다.
title: ''
labels: enhancement
assignees: ''

---

## 무슨 이유로 코드를 변경했는가
- [x] 신규 기능
- [x] 기능 수정
- [ ] 버그 픽스

## 어떤 위험이나 장애가 발견되었는지 (버그 픽스인 경우)
- 
-

## 어떤 부분에 리뷰어가 집중하면 좋은가
- 

## 관련 스크린 샷

## 테스트 계획 또는 완료 사항
- [x] rt기반으로 새로운 at를 발급
- [x] 로그아웃 시, rt를 redis에서 삭제 및 쿠키에서도 삭제
