### PR TITLE
[일정] 일정 생성 시 메일 발송 기능 추가

### DIFF
--- a/src/main/java/com/threeping/syncday/SyncdayApplication.java
+++ b/src/main/java/com/threeping/syncday/SyncdayApplication.java
@@ -2,11 +2,13 @@ package com.threeping.syncday;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 //@SpringBootApplication(exclude={SecurityAutoConfiguration.class})
 @EnableScheduling
+@EnableAsync(proxyTargetClass = true)
 public class SyncdayApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/threeping/syncday/notification/service/NotificationScheduler.java
+++ b/src/main/java/com/threeping/syncday/notification/service/NotificationScheduler.java
@@ -21,7 +21,7 @@ public class NotificationScheduler {
         this.infraNotificationService = infraNotificationService;
     }
 
-//    @Scheduled(cron = "0 5/10 * * * ?")
+    @Scheduled(cron = "0 5/10 * * * ?")
     public void scheduleNotificationJob(){
         log.info("일정 알림 scheduling job 실행 시작");
 

--- a/src/main/java/com/threeping/syncday/schedule/command/Infrastructure/InfraScheduleService.java
+++ b/src/main/java/com/threeping/syncday/schedule/command/Infrastructure/InfraScheduleService.java
@@ -1,10 +1,21 @@
 package com.threeping.syncday.schedule.command.Infrastructure;
 
+import com.threeping.syncday.user.command.application.dto.UserDTO;
+import org.springframework.scheduling.annotation.Async;
+
 import java.sql.Timestamp;
 import java.util.List;
+import java.util.Map;
 
 public interface InfraScheduleService {
     void requestAddScheduleParticipant(Long userId, Long scheduleId, List<Long> attendeeIds, Timestamp notificationTime);
 
     void requestUpdateScheduleParticipant(Long userId, Long scheduleId, List<Long> attendeeIds);
+
+    UserDTO findUserById(Long userId);
+
+    @Async
+    void sendMailToParticipants(List<String> emails,
+                                String title,
+                                Map<String, Object> varMap);
 }

--- a/src/main/java/com/threeping/syncday/schedule/command/Infrastructure/InfraScheduleServiceImpl.java
+++ b/src/main/java/com/threeping/syncday/schedule/command/Infrastructure/InfraScheduleServiceImpl.java
@@ -1,20 +1,42 @@
 package com.threeping.syncday.schedule.command.Infrastructure;
 
 import com.threeping.syncday.scheduleparticipant.command.application.service.AppScheduleParticipantService;
+import com.threeping.syncday.user.command.application.dto.UserDTO;
+import com.threeping.syncday.user.query.service.UserQueryService;
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.MimeMessage;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
+import org.thymeleaf.TemplateEngine;
+import org.thymeleaf.context.Context;
 
 import java.sql.Timestamp;
 import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 
 @Service
+@Slf4j
 public class InfraScheduleServiceImpl implements InfraScheduleService{
 
     private final AppScheduleParticipantService appScheduleParticipantService;
+    private final UserQueryService userQueryService;
+    private final JavaMailSender javaMailSender;
+    private final TemplateEngine templateEngine;
 
     @Autowired
-    public InfraScheduleServiceImpl(AppScheduleParticipantService appScheduleParticipantService) {
+    public InfraScheduleServiceImpl(AppScheduleParticipantService appScheduleParticipantService,
+                                    UserQueryService userQueryService,
+                                    JavaMailSender javaMailSender,
+                                    TemplateEngine templateEngine) {
         this.appScheduleParticipantService = appScheduleParticipantService;
+        this.userQueryService = userQueryService;
+        this.javaMailSender = javaMailSender;
+        this.templateEngine = templateEngine;
     }
 
     @Override
@@ -25,5 +47,46 @@ public class InfraScheduleServiceImpl implements InfraScheduleService{
     @Override
     public void requestUpdateScheduleParticipant(Long userId, Long scheduleId, List<Long> attendeeIds) {
         appScheduleParticipantService.updateScheduleParticipant(userId, scheduleId, attendeeIds);
+    }
+
+    @Override
+    public UserDTO findUserById(Long userId){
+        return userQueryService.findById(userId);
+    }
+
+    @Async
+    @Override
+    public void sendMailToParticipants(List<String> emails,
+                                       String title,
+                                       Map<String, Object> varMap){
+        try{
+            MimeMessage[] mimeMessages = emails.stream().map(
+                    email -> {
+                        try {
+                            MimeMessage mimeMessage = javaMailSender.createMimeMessage();
+                            MimeMessageHelper helper = new MimeMessageHelper(mimeMessage, false, "UTF-8");
+                            helper.setTo(email);
+                            helper.setSubject(title);
+                            helper.setText(setContext(varMap),true);
+                            return mimeMessage;
+                        } catch (MessagingException e) {
+                            log.info("Failed to create email for :{}",email,e);
+                            return null;
+                        }
+                    }).filter(Objects::nonNull)
+                    .toArray(MimeMessage[]::new);
+
+            javaMailSender.send(mimeMessages);
+            log.info("emails sent");
+        } catch (Exception e){
+            log.info("Failed to send emails",e);
+        }
+
+    }
+
+    private String setContext(Map<String,Object> varMap) {
+        Context context = new Context();
+        context.setVariables(varMap);
+        return templateEngine.process("SCHEDULE", context);
     }
 }

--- a/src/main/java/com/threeping/syncday/schedule/command/application/controller/AppScheduleController.java
+++ b/src/main/java/com/threeping/syncday/schedule/command/application/controller/AppScheduleController.java
@@ -1,6 +1,7 @@
 package com.threeping.syncday.schedule.command.application.controller;
 
 import com.threeping.syncday.common.ResponseDTO;
+import com.threeping.syncday.schedule.command.Infrastructure.InfraScheduleServiceImpl;
 import com.threeping.syncday.schedule.command.aggregate.dto.ScheduleDTO;
 import com.threeping.syncday.schedule.command.application.service.AppScheduleService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -15,11 +16,11 @@ import org.springframework.web.bind.annotation.*;
 @Slf4j
 @RestController
 @RequestMapping("/api/schedule")
-public class AppScheduleController {
+public class  AppScheduleController {
     private final AppScheduleService appScheduleService;
 
     @Autowired
-    public AppScheduleController(AppScheduleService appScheduleService) {
+    public AppScheduleController(AppScheduleService appScheduleService, InfraScheduleServiceImpl infraScheduleServiceImpl) {
         this.appScheduleService = appScheduleService;
     }
 
@@ -35,7 +36,11 @@ public class AppScheduleController {
     )
     @PostMapping("")
     public ResponseDTO<?> createSchedule(@RequestBody ScheduleDTO newSchedule) {
-        return ResponseDTO.ok(appScheduleService.addSchedule(newSchedule));
+        ScheduleDTO createdScheduleDTO = appScheduleService.addSchedule(newSchedule);
+        log.info("생성된 스케줄{}",createdScheduleDTO);
+        appScheduleService.sendMailToParticipants(createdScheduleDTO);
+        return ResponseDTO.ok(createdScheduleDTO);
+
     }
 
     @Operation(summary = "일정 수정",

--- a/src/main/java/com/threeping/syncday/schedule/command/application/service/AppScheduleService.java
+++ b/src/main/java/com/threeping/syncday/schedule/command/application/service/AppScheduleService.java
@@ -9,4 +9,6 @@ public interface AppScheduleService {
     ScheduleDTO modifySchedule(ScheduleDTO newSchedule, Long scheduleId);
 
     ScheduleDTO deleteSchedule(Long scheduleId);
+
+    void sendMailToParticipants(ScheduleDTO createdScheduleDTO);
 }

--- a/src/main/java/com/threeping/syncday/schedule/command/application/service/AppScheduleServiceImpl.java
+++ b/src/main/java/com/threeping/syncday/schedule/command/application/service/AppScheduleServiceImpl.java
@@ -6,6 +6,7 @@ import com.threeping.syncday.schedule.command.Infrastructure.InfraScheduleServic
 import com.threeping.syncday.schedule.command.aggregate.dto.ScheduleDTO;
 import com.threeping.syncday.schedule.command.aggregate.entity.Schedule;
 import com.threeping.syncday.schedule.command.domain.repository.ScheduleRepository;
+import com.threeping.syncday.user.command.application.dto.UserDTO;
 import jakarta.transaction.Transactional;
 import lombok.extern.slf4j.Slf4j;
 import org.modelmapper.ModelMapper;
@@ -14,6 +15,9 @@ import org.springframework.stereotype.Service;
 
 import java.sql.Timestamp;
 import java.time.Instant;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 @Slf4j
 @Service
@@ -54,9 +58,9 @@ public class AppScheduleServiceImpl implements AppScheduleService{
                 , newScheduleDTO.getAttendeeIds()
                 , newScheduleDTO.getNotificationTime());
 
-        // 참석자 추가 요청 (반복 생각은 아직 안함)
-
-        return modelMapper.map(newSchedule, ScheduleDTO.class);
+        ScheduleDTO createdScheduleDTO = modelMapper.map(newSchedule, ScheduleDTO.class);
+        createdScheduleDTO.setAttendeeIds(newScheduleDTO.getAttendeeIds());
+        return createdScheduleDTO;
     }
 
     @Transactional
@@ -99,5 +103,25 @@ public class AppScheduleServiceImpl implements AppScheduleService{
         scheduleRepository.delete(newSchedule);
         
         return modelMapper.map(newSchedule, ScheduleDTO.class);
+    }
+
+    @Override
+    public void sendMailToParticipants(ScheduleDTO createdScheduleDTO) {
+        List<String> emails = createdScheduleDTO.getAttendeeIds().stream().map(
+                id->{
+                    UserDTO userDTO = infraScheduleService.findUserById(id);
+                    return userDTO.getEmail();
+                }
+        ).toList();
+        UserDTO userDTO = infraScheduleService.findUserById(createdScheduleDTO.getUserId());
+        String userName = userDTO.getUserName();
+        String userPosition = userDTO.getPosition();
+        String title = "[SyncDay]" + userName + "(" + userPosition + ")" + " 님의 " + createdScheduleDTO.getTitle() + " 일정 초대 안내 메일";
+        Map<String,Object> varMap = new HashMap<>();
+        varMap.put("sender",userName + "(" + userPosition + ")");
+        varMap.put("title",createdScheduleDTO.getTitle());
+        varMap.put("date",createdScheduleDTO.getStartTime() + " ~ " + createdScheduleDTO.getEndTime());
+        varMap.put("scheduleId",createdScheduleDTO.getScheduleId());
+        infraScheduleService.sendMailToParticipants(emails,title,varMap);
     }
 }

--- a/src/main/java/com/threeping/syncday/scheduleparticipant/command/application/service/AppScheduleParticipantServiceImpl.java
+++ b/src/main/java/com/threeping/syncday/scheduleparticipant/command/application/service/AppScheduleParticipantServiceImpl.java
@@ -105,6 +105,7 @@ public class AppScheduleParticipantServiceImpl implements AppScheduleParticipant
     // 참여 상태 수정
     @Override
     public ResponseScheduleParticipantDTO updateUserScheduleStatus(ScheduleParticipantStatusDTO newScheduleParticipantStatus) {
+        log.info("newScheduleParticipantsDTO: {}",newScheduleParticipantStatus);
         ScheduleParticipant currentParticipant = scheduleParticipantRepository.findByScheduleIdAndUserId(
                 newScheduleParticipantStatus.getScheduleId(), newScheduleParticipantStatus.getUserId()
         );

--- a/src/main/resources/com/threeping/syncday/schedule/query/repository/ScheduleMapper.xml
+++ b/src/main/resources/com/threeping/syncday/schedule/query/repository/ScheduleMapper.xml
@@ -58,6 +58,7 @@
         <result property="userId" column="user_id"></result>
         <result property="username" column="username"></result>
         <result property="status" column="status"></result>
+        <result property="notificationTime" column="notification_time"></result>
     </resultMap>
 
     <select id="selectMySchedulesByUserId" resultMap="scheduleResultMap" parameterType="long">
@@ -178,6 +179,7 @@
           LEFT JOIN TBL_USER PARTICIPANT -- 참여자와 조인
             ON US.USER_ID = PARTICIPANT.USER_ID
          WHERE US.USER_ID = #{userId}
-           AND DATE(S.START_TIME) = CURDATE();
+           AND DATE(S.START_TIME) = CURDATE()
+         ORDER BY S.START_TIME
     </select>
 </mapper>

--- a/src/main/resources/templates/SCHEDULE.html
+++ b/src/main/resources/templates/SCHEDULE.html
@@ -1,73 +1,157 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org" lang="kr">
 <head>
+    <meta charset="UTF-8">
     <title>일정 참여 요청 알림</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            color: #333;
+            background-color: #f3f4f6;
+            margin: 0;
+            padding: 0;
+        }
+
+        .email-container {
+            max-width: 600px;
+            margin: 40px auto;
+            background-color: #ffffff;
+            border-radius: 12px;
+            overflow: hidden;
+            box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+        }
+
+        .header {
+            background-color: #FF9D85;
+            color: white;
+            padding: 16px;
+            text-align: center;
+            font-size: 24px;
+            font-weight: bold;
+        }
+
+        .content {
+            padding: 24px;
+            text-align: center;
+        }
+
+        .content h2 {
+            color: #333;
+            font-size: 20px;
+            margin-bottom: 16px;
+        }
+
+        .content p {
+            font-size: 16px;
+            color: #555;
+            line-height: 1.5;
+        }
+
+        .details-table {
+            width: 100%;
+            border-collapse: collapse;
+            margin: 20px 0;
+        }
+
+        .details-table th, .details-table td {
+            padding: 12px;
+            text-align: left;
+            font-size: 14px;
+        }
+
+        .details-table th {
+            background-color: #f3f4f6;
+            font-weight: bold;
+            color: #666;
+        }
+
+        .details-table td {
+            border-bottom: 1px solid #eaeaea;
+        }
+
+        .buttons {
+            margin: 20px 0;
+            text-align: center;
+        }
+
+        .buttons a {
+            display: inline-block;
+            padding: 12px 24px;
+            margin: 0 10px;
+            text-decoration: none;
+            border-radius: 24px;
+            font-size: 16px;
+            font-weight: bold;
+            color: #fff;
+            box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .accept-button {
+            background-color: #FE5D86;
+            cursor: pointer;
+        }
+
+        .decline-button {
+            background-color: #646464;
+            cursor: pointer;
+        }
+
+        .footer {
+            font-size: 12px;
+            color: #777;
+            text-align: center;
+            padding: 16px;
+            background-color: #f3f4f6;
+        }
+    </style>
 </head>
-<body style="font-family: Arial, sans-serif; color: #333; background: linear-gradient(135deg, #fcb69f, #ff8177); padding: 20px; text-align: center;">
+<body>
+<div class="email-container">
+    <!-- Header -->
+    <div class="header">
+        SYNCDAY
+    </div>
 
-<!-- Header with SYNDAY logo -->
-<div style="font-size: 24px; font-weight: bold; color: #ffffff; padding: 10px 0;">
-    SYNCDAY
-</div>
+    <!-- Content -->
+    <div class="content">
+        <h2>일정 참여 요청</h2>
+        <p>
+            <strong th:text="${sender}">발신자</strong>님이
+            <strong th:text="${title}">일정명</strong> 일정에 참여를 요청하셨습니다.
+        </p>
 
-<!-- Notification Container -->
-<div style="max-width: 600px; margin: 20px auto; background-color: rgba(255, 255, 255, 0.8); border-radius: 12px; overflow: hidden; padding: 20px; box-shadow: 0px 4px 12px rgba(0, 0, 0, 0.1);">
+        <!-- Details Table -->
+        <table class="details-table">
+            <tr>
+                <th>일정명</th>
+                <td th:text="${title}">일정명</td>
+            </tr>
+            <tr>
+                <th>발신자</th>
+                <td th:text="${sender}">발신자</td>
+            </tr>
+            <tr>
+                <th>일시</th>
+                <td th:text="${date}">일시</td>
+            </tr>
+        </table>
 
-    <!-- Notification Title -->
-    <h2 style="color: #ff8177; margin: 0 0 10px;">일정 참여 요청 알림</h2>
-    <p style="color: #555; font-size: 16px;">
-        <strong th:text="${sender}">발신자</strong>님이 <strong th:text="${title}">일정명</strong> 일정에 참여를 요청하셨습니다.
-    </p>
+        <!-- Action Buttons -->
+        <div class="buttons">
+            <a
+                    th:href="@{'http://localhost:5173/invitation/mail-link?scheduleId=' + ${scheduleId} + '&status=ATTEND'}"
+                    class="accept-button"> 참석
+            </a>
+            <a
+                    th:href="@{'http://localhost:5173/invitation/mail-link?scheduleId=' + ${scheduleId} + '&status=ABSENT'}"
+                    class="decline-button"> 불참
+            </a>
+        </div>
+    </div>
 
-    <!-- Table with Event Details -->
-    <table style="width: 100%; border-collapse: collapse; margin-top: 20px; font-size: 14px; color: #333;">
-        <tr style="background-color: #ffe6e1;">
-            <td style="padding: 10px; text-align: left; font-weight: bold;">일정명</td>
-            <td style="padding: 10px; text-align: right;" th:text="${title}">일정명</td>
-        </tr>
-        <tr style="background-color: #ffd1cc;">
-            <td style="padding: 10px; text-align: left; font-weight: bold;">발신자</td>
-            <td style="padding: 10px; text-align: right;" th:text="${sender}">발신자</td>
-        </tr>
-        <tr style="background-color: #ffe6e1;">
-            <td style="padding: 10px; text-align: left; font-weight: bold;">일시</td>
-            <td style="padding: 10px; text-align: right;" th:text="${date}">날짜</td>
-        </tr>
-        <tr style="background-color: #ffd1cc;">
-            <td style="padding: 10px; text-align: left; font-weight: bold;">위치</td>
-            <td style="padding: 10px; text-align: right;" th:text="${location}">위치</td>
-        </tr>
-    </table>
-
-    <!-- Buttons -->
-    <div style="margin-top: 20px;">
-        <a href="http://localhost:5000/api/accept" style="
-                display: inline-block;
-                padding: 12px 24px;
-                margin: 0 5px;
-                color: #ffffff;
-                background-color: #ff8177;
-                text-decoration: none;
-                border-radius: 24px;
-                font-size: 16px;
-                font-weight: bold;
-                box-shadow: 0px 4px 8px rgba(255, 129, 119, 0.3);">
-            참여 가능
-        </a>
-
-        <a href="http://localhost:5000/api/decline" style="
-                display: inline-block;
-                padding: 12px 24px;
-                margin: 0 5px;
-                color: #ffffff;
-                background-color: #ffd1cc;
-                text-decoration: none;
-                border-radius: 24px;
-                font-size: 16px;
-                font-weight: bold;
-                box-shadow: 0px 4px 8px rgba(255, 209, 204, 0.3);">
-            참여 불가
-        </a>
+    <!-- Footer -->
+    <div class="footer">
+        이 메일은 SYNDAY 시스템에 의해 자동 발송되었습니다.
     </div>
 </div>
 </body>


### PR DESCRIPTION
---
name: [일정] 일정 생성 시 메일 발송 기능 추가
about: 
일정을 생성하게 되면 참석자들에게 참석 여부를 확인하는 메일을 발송합니다. 참석자들은 참석 여부를 해당 메일과, 본인의 메인 페이지와, 네비게이션바에 위치한 초대장 아이콘을 눌러서 이동하는 일정초대 페이지에서 선택할 수 있습니다.
title: ''
labels: enhancement
assignees: ''

---

## 무슨 이유로 코드를 변경했는가
- [x] 신규 기능
- [ ] 기능 수정
- [ ] 버그 픽스

## 어떤 위험이나 장애가 발견되었는지 (버그 픽스인 경우)
- 
-

## 어떤 부분에 리뷰어가 집중하면 좋은가
- 

## 관련 스크린 샷

## 테스트 계획 또는 완료 사항
- [ ] 테스트항목 1
- [ ] 테스트항목 2
